### PR TITLE
DRMAAV2-25: Add thread-safe lasterror in c-binding

### DIFF
--- a/api/c-binding/drmaa2.cpp
+++ b/api/c-binding/drmaa2.cpp
@@ -53,6 +53,14 @@ extern "C" {
 #include <stdio.h>
 
 /**
+ *  @brief __last_error is thread-local and Thead-safe. Setting it in one
+ *  thread  does not affect its value in any other thread.
+ */
+__thread drmaa2_error __last_error = DRMAA2_SUCCESS;
+extern __thread drmaa2_error __last_error;
+
+
+/**
  *  @brief  frees the previously allocated drmaa2_string
  *
  *  @param[in]	str - pointer to pre allocated drmaa2_string
@@ -71,8 +79,7 @@ void drmaa2_string_free(drmaa2_string * str) {
  *
  */
 drmaa2_error drmaa2_lasterror(void) {
-	//TODO Add Code here
-	return DRMAA2_SUCCESS;
+	return lasterror;
 }
 
 /**
@@ -83,8 +90,10 @@ drmaa2_error drmaa2_lasterror(void) {
  *
  */
 drmaa2_string drmaa2_lasterror_text(void) {
-	//TODO Add Code here
-	return NULL;
+	if (lasterror <= DRMAA2_UNSET_ERROR && lasterror >= DRMAA2_LASTERROR) {
+		return NULL;
+	}
+	return (char*)last_error_text[lasterror];
 }
 
 /**

--- a/api/c-binding/drmaa2.h
+++ b/api/c-binding/drmaa2.h
@@ -43,6 +43,9 @@ extern "C" {
 #endif
 
 #include <time.h>
+
+#define lasterror __last_error
+
 extern const char * const DRMAA2_CORE_FILE_SIZE;
 
 extern const char * const DRMAA2_CPU_TIME;
@@ -158,6 +161,23 @@ typedef enum drmaa2_error {
 } drmaa2_error;
 
 typedef char *drmaa2_string;
+
+const char *last_error_text[DRMAA2_LASTERROR+1] = {"Success",
+	"Denied by DRMS",
+	"Failed to communicating with DRMS",
+	"Try later",
+	"Session Management",
+	"Operation Timed out",
+	"Internal Error",
+	"Invalid argument",
+	"Invalid state",
+	"Invalid session",
+	"Out of resource",
+	"Unsupported attribute",
+	"Unsupported operation",
+	"Implementation specific error",
+	"Last"};
+
 
 void drmaa2_string_free(drmaa2_string *);
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[DRMAAV2-25](https://pbspro.atlassian.net/browse/DRMAAV2-25)**

#### Problem description
* Thread-safe lasterror 

#### Cause / Analysis
* Briefly describe root cause/analysis of the problem

#### Solution description
*  The  language  binding  adds  two  new  functions  for  fetching  error  number  and  error  message of  the  last error that occurred: drmaa2_lasterror and drmaa2_lasterror_text
.  These functions MUST operate in a  thread-safe  manner,  meaning  that  both  error  informations are  managed  per  application  thread  by  the DRMAA implementation.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **unit test(s) to my commit**. *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why unit testing is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. 
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
